### PR TITLE
Changing Example 1 from echoip.com to canhazip.com

### DIFF
--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -67,7 +67,7 @@ $(function()
 
 	// Fill in examples
 	$('#example1').click(function() {
-		$('#input').val('curl echoip.com').keyup();
+		$('#input').val('curl canhazip.com').keyup();
 	});
 	$('#example2').click(function() {
 		$('#input').val('curl https://api.example.com/surprise \\\n     -u banana:coconuts \\\n     -d "sample data"').keyup();


### PR DESCRIPTION
I'm not sure about the history of echoip.com, but it currently doesn't resolve. canhazip.com is reliable and stays simple.

I don't have any affiliation to either site, just thought a usable example would be better.
