### PR TITLE
Added service worker with cache first strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,15 @@
 	<head>
 		<title>curl-to-Go: Convert curl commands to Go code</title>
 		<meta charset="utf-8">
+		<script>
+			if ('serviceWorker' in navigator) {
+				navigator.serviceWorker.register('./sw.js').then(function(reg) {
+					console.log('Successfully registered service worker', reg);
+				}).catch(function(err) {
+					console.warn('Error whilst registering service worker', err);
+				})
+			}
+		</script>
 		<script src="resources/js/jquery.min.js"></script>
 		<script src="resources/js/highlight.pack.js"></script>
 		<script src="resources/js/common.js"></script>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,43 @@
+var CACHE = "v1:static"
+
+var filesToCache = [
+    './',
+    'resources/js/jquery.min.js',
+    'resources/js/highlight.pack.js',
+    'resources/js/common.js',
+    'https://mholt.github.io/json-to-go/resources/js/json-to-go.js',
+    'resources/js/curl-to-go.js',
+    'resources/js/gofmt.js',
+    'resources/css/color-brewer.css',
+    'resources/css/common.css'
+]
+
+self.addEventListener('install', function (evt) {
+    console.log('Attempting service worker installation.');
+
+    // Wait until promise resolves
+    evt.waitUntil(precache());
+});
+
+// On fetch, return from cache
+self.addEventListener('fetch', function (evt) {
+    evt.respondWith(fromCache(evt.request));
+});
+
+// Opens cache and loads filesToCache into cache
+// for using them in future
+function precache() {
+    return caches.open(CACHE).then(function (cache) {
+        return cache.addAll(filesToCache);
+    });
+}
+
+// When a resource is requested respond only from service worker.
+// This strategy is cache first.
+function fromCache(request) {
+    return caches.open(CACHE).then(function (cache) {
+        return cache.match(request).then(function (matching) {
+            return matching || fetch(request);
+        }).catch(console.error);
+    });
+}


### PR DESCRIPTION
This PR is similar to [this](https://github.com/mholt/json-to-go/pull/30) in `json-to-go`. It also adds a service worker with cache first strategy so it can be used even when the internet is not working.

If there is a change in any file that is cached by the service worker, Simply changing the value of `CACHE` variable in `sw.js` will ensure that everyone using the tool will receive the most recent version of a file. 

Regards 
Ishan Jain