### PR TITLE
#27 add -k and --insecure support

### DIFF
--- a/resources/js/curl-to-go.js
+++ b/resources/js/curl-to-go.js
@@ -41,10 +41,14 @@ function curlToGo(curl) {
 
 	var req = extractRelevantPieces(cmd);
 
+	var res = promo;
+	if (cmd['k'] || cmd['insecure']) {
+		res += "\nhttp.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}\n\n";
+	}
 	if (Object.keys(req.headers).length == 0 && !req.data.ascii && !req.data.files && !req.basicauth) {
-		return promo+"\n"+renderSimple(req.method, req.url);
+		return res+"\n\n"+renderSimple(req.method, req.url);
 	} else {
-		return promo+"\n\n"+renderComplex(req);
+		return res+"\n\n"+renderComplex(req);
 	}
 
 
@@ -432,7 +436,7 @@ function parseCommand(input, options) {
 				if (!(cursor < input.length-1 && input[cursor+1] == '$'))
 					continue;
 			}
-			
+
 			str += input[cursor];
 			escaped = false;
 		}

--- a/resources/js/curl-to-go.js
+++ b/resources/js/curl-to-go.js
@@ -70,6 +70,7 @@ function curlToGo(curl) {
 		// insecure
 		// -k or --insecure
 		if (req.insecure) {
+			go += '// TODO: This is insecure; use only in dev environments.\n';
 			go += 'tr := &http.Transport{\n' +
 				'        TLSClientConfig: &tls.Config{InsecureSkipVerify: true},\n' +
 				'    }\n' +

--- a/resources/js/curl-to-go.js
+++ b/resources/js/curl-to-go.js
@@ -44,7 +44,6 @@ function curlToGo(curl) {
 	if (Object.keys(req.headers).length == 0 && !req.data.ascii && !req.data.files && !req.basicauth && !req.insecure) {
 		return promo+"\n"+renderSimple(req.method, req.url);
 	} else {
-		console.log(promo+"\n\n"+renderComplex(req));
 		return promo+"\n\n"+renderComplex(req);
 	}
 


### PR DESCRIPTION
#27 

It will generate a client that could not check certificate.

for example:

```
curl http://www.google.com -k
```

```golang
// Generated by curl-to-Go: https://mholt.github.io/curl-to-go

// TODO: This is insecure; use only in dev environments.
tr := &http.Transport{
	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
}
client := &http.Client{Transport: tr}

req, err := http.NewRequest("GET", "https://google.com", nil)
if err != nil {
	// handle err
}

resp, err := client.Do(req)
if err != nil {
	// handle err
}
defer resp.Body.Close()
```