### PR TITLE
Tighten up basic auth logic

### DIFF
--- a/resources/js/curl-to-go.js
+++ b/resources/js/curl-to-go.js
@@ -244,14 +244,19 @@ function curlToGo(curl) {
 			basicAuthString = cmd.user[cmd.user.length-1];
 		else if (cmd.u && cmd.u.length > 0)
 			basicAuthString = cmd.u[cmd.u.length-1];
-		var basicAuthSplit = basicAuthString.indexOf(":");
-		if (basicAuthSplit > -1) {
-			relevant.basicauth = {
-				user: basicAuthString.substr(0, basicAuthSplit),
-				pass: basicAuthString.substr(basicAuthSplit+1)
-			};
-		} else {
-			relevant.basicAuth = { user: basicAuthString, pass: "<PASSWORD>" };
+		// if the -u or --user flags haven't been set then don't set the
+		// basicauth property.
+		if (basicAuthString) {
+			var basicAuthSplit = basicAuthString.indexOf(":");
+			if (basicAuthSplit > -1) {
+				relevant.basicauth = {
+					user: basicAuthString.substr(0, basicAuthSplit),
+					pass: basicAuthString.substr(basicAuthSplit+1)
+				};
+			} else {
+				// the user has not provided a password
+				relevant.basicauth = { user: basicAuthString, pass: "<PASSWORD>" };
+			}
 		}
 
 		// default to GET if nothing else specified


### PR DESCRIPTION
We only need to set the `basicauth` property if a user has provided a `-u` or `--user` flag.