### PR TITLE
Added support for urlencoded form content type

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 			<h2>Instantly convert <a href="http://curl.haxx.se/">curl</a> commands to <a href="https://golang.org/">Go</a> code</h2>
 
 			<p>
-				This tool turns a curl command into Go code. (To do the reverse, check out <a href="https://github.com/sethgrid/gencurl">sethgrid/gencurl</a>.) Currently, it knows the following options: -d/--data, -H/--header, -I/--head, -u/--user, --url, and -X/--request. It also understands JSON content types (see <a href="https://mholt.github.io/json-to-go">JSON-to-Go</a>). Feel free to <a href="https://github.com/mholt/curl-to-go">contribute on GitHub</a>!
+				This tool turns a curl command into Go code. (To do the reverse, check out <a href="https://github.com/sethgrid/gencurl">sethgrid/gencurl</a>.) Currently, it knows the following options: -d/--data, -H/--header, -I/--head, -u/--user, --url, and -X/--request. It also understands JSON content types (see <a href="https://mholt.github.io/json-to-go">JSON-to-Go</a>). If the content type is application/x-www-form-urlencoded then it will convert the date to <a href="https://pkg.go.dev/net/url#Values">Values</a>(same as <a href="https://pkg.go.dev/net/http#Client.PostForm">PostForm</a>). Feel free to <a href="https://github.com/mholt/curl-to-go">contribute on GitHub</a>!
 			</p>
 
 			<p class="examples">
@@ -36,7 +36,8 @@
 				<a href="javascript:" id="example2">Example 2</a> &middot;
 				<a href="javascript:" id="example3">Example 3</a> &middot;
 				<a href="javascript:" id="example4">Example 4</a> &middot;
-				<a href="javascript:" id="example5">Example 5</a>
+				<a href="javascript:" id="example5">Example 5</a> &middot;
+        <a href="javescript:" id="example6">Example 6</a>
 			</p>
 		</header>
 

--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -85,6 +85,9 @@ $(function()
 	$('#example5').click(function() {
 		$('#input').val("curl -X POST https://api.easypost.com/v2/shipments \\\n     -u API_KEY: \\\n     -d 'shipment[to_address][id]=adr_HrBKVA85' \\\n     -d 'shipment[from_address][id]=adr_VtuTOj7o' \\\n     -d 'shipment[parcel][id]=prcl_WDv2VzHp' \\\n     -d 'shipment[is_return]=true' \\\n     -d 'shipment[customs_info][id]=cstinfo_bl5sE20Y'").keyup();
 	});
+  $('#example6').click(function(){
+    $('#input').val('curl https://api.example.com/surprise -X POST -H "Content-Type: application/x-www-form-urlencoded" \\\n     --data "key1=value+1&key2=value%3A2"').keyup();
+  });
 
 	var dark = false;
 	$("#dark").click(function()

--- a/resources/js/curl-to-go.js
+++ b/resources/js/curl-to-go.js
@@ -113,7 +113,14 @@ function curlToGo(curl) {
 						go += 'payloadBytes, err := json.Marshal(data)\n'+err;
 						go += defaultPayloadVar+' := bytes.NewReader(payloadBytes)\n\n';
 					}
-				} else {
+				} else if(req.headers["Content-Type"] && req.headers["Content-Type"] == "application/x-www-form-urlencoded") {
+						go += "params := url.Values{}\n"
+						var params = new URLSearchParams(req.data.ascii);
+						params.forEach(function(fvalue, fkey){
+							go += 'params.Add("' + fkey + '", `' + fvalue + '`)\n' 
+						});
+						go += defaultPayloadVar+ ' := strings.NewReader(params.Encode())\n\n'
+				}else {
 					// not a json Content-Type, so treat as string
 					stringBody();
 				}


### PR DESCRIPTION
Added support for form encoded data,

Example:
```
// Generated by curl-to-Go: https://mholt.github.io/curl-to-go

// curl https://api.example.com/surprise -X POST -H "Content-Type: application/x-www-form-urlencoded" \
//      --data "key1=value+1&key2=value%3A2"

params := url.Values{}
params.Add("key1", `value 1`)
params.Add("key2", `value:2`)
body := strings.NewReader(params.Encode())

req, err := http.NewRequest("POST", "https://api.example.com/surprise", body)
if err != nil {
	// handle err
}
req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

resp, err := http.DefaultClient.Do(req)
if err != nil {
	// handle err
}
defer resp.Body.Close()
```