### PR TITLE
removed typo for example 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 				<a href="javascript:" id="example3">Example 3</a> &middot;
 				<a href="javascript:" id="example4">Example 4</a> &middot;
 				<a href="javascript:" id="example5">Example 5</a> &middot;
-        <a href="javescript:" id="example6">Example 6</a>
+        		<a href="javascript:" id="example6">Example 6</a>
 			</p>
 		</header>
 


### PR DESCRIPTION
I saw a Typo for the example 6. It was written _javescript_ instead of _javascript_ in the html